### PR TITLE
fix: copy migrations directory into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /usr/share/zoneinfo                /usr/share/zoneinfo
 COPY --from=builder /app/gogear-api                    /app/gogear-api
 COPY --from=builder /bin/sh                            /bin/sh
+COPY migrations                                         /app/migrations
 
 USER abc:abc
 


### PR DESCRIPTION
## Problem

After adding golang-migrate (#447), the Docker image is missing the `migrations/` directory at runtime:

```
Failed to run database migrations: migration instance init: 
failed to open source, "file://migrations": open .: no such file or directory
```

## Fix

Add `COPY migrations /app/migrations` to the final stage of the Dockerfile.

The `WORKDIR` is `/app` and `runMigrations(db, "migrations", log)` resolves relative to that — so the SQL files land at `/app/migrations/` where the code expects them.